### PR TITLE
[Web] ファイルを開くダイアログの結果が返らないことがある問題の修正

### DIFF
--- a/Siv3D/lib/Web/jslib/Siv3D.Dialog.js
+++ b/Siv3D/lib/Web/jslib/Siv3D.Dialog.js
@@ -17,8 +17,22 @@ mergeInto(LibraryManager.library, {
         siv3dInputElement.accept = UTF8ToString(filterStr);
         siv3dInputElement.multiple = !!acceptMuilitple;
 
+        function cancelHandler(e) {
+            {{{ makeDynCall('viii', 'callback') }}}(0, 0, futurePtr);
+            _siv3dMaybeAwake();
+        }
+
+        // Using addEventListener works in Firefox
+        // Set 'once' to automatically delete the handler when the event fires
+        siv3dInputElement.addEventListener('cancel', cancelHandler, { once: true });
+
         siv3dInputElement.oninput = async function(e) {
-            const files = e.target.files;
+            // Delete event handler if cancel event is not fired
+            siv3dInputElement.removeEventListener('cancel', cancelHandler);
+
+            // Workaround for event firing
+            const files = [...e.target.files];
+            e.target.value = '';
 
             if (files.length < 1) {
                 {{{ makeDynCall('viii', 'callback') }}}(0, 0, futurePtr);


### PR DESCRIPTION
https://github.com/nokotan/OpenSiv3D/issues/49 についての修正です。

前回と同じファイルが選択されたとき `input` イベントが発火しない現象に対し、ファイルが選択されるごとに input 要素の value を空にすることで回避しています。また、連続でファイルが選択されなかった時にもイベントは発火せず、その場合は上記の方法では回避できないので、cancel イベントを使用しています。

`.oncancel` にハンドラを設定する方法では Firefox で動作しなかった（原因不明）ため、`addEventListener` を使用しています。それに伴い、ハンドラの多重登録を防ぐため、cancel イベントが発火した場合はハンドラが自動で削除されるよう once オプションを設定し、input イベントが発火した場合は `removeEventListener` でハンドラを削除しています。
